### PR TITLE
Raise TypeError in favor of Exception

### DIFF
--- a/lib/type_hinting.rb
+++ b/lib/type_hinting.rb
@@ -17,7 +17,7 @@ module TypeHinting
       define_method(name) do |*args|
         r = method.bind(self).call(*args)
         unless r.kind_of?(type)
-          raise Exception, "Invalid return type of #{r.class}, expecting #{type}"
+          raise TypeError, "Invalid return type of #{r.class}, expecting #{type}"
         end
         r
       end
@@ -29,7 +29,7 @@ module TypeHinting
       define_method(name) do |*args|
         arg_types.zip(sig_args, args).each do |(type, (required, name), arg)|
           if !arg.kind_of?(type) && !skipped_optional_param(required, arg)
-            raise Exception, "Invalid type #{arg.class} for " <<
+            raise TypeError, "Invalid type #{arg.class} for " <<
               "parameter #{name}, expecting #{type}"
           end
         end

--- a/lib/type_hinting/version.rb
+++ b/lib/type_hinting/version.rb
@@ -1,3 +1,3 @@
 module TypeHinting
-  VERSION = "0.0.2"
+  VERSION = "0.1.0"
 end

--- a/spec/type_hinting_spec.rb
+++ b/spec/type_hinting_spec.rb
@@ -25,7 +25,7 @@ describe TypeHinting do
   describe '.return_type' do
 
     it 'raises when method returns other than specified return type' do
-      expect{h.return_should_raise}.to raise_error
+      expect{h.return_should_raise}.to raise_error(TypeError)
     end
 
     it 'doesnt raise when method returns the specified return type' do
@@ -36,9 +36,9 @@ describe TypeHinting do
   describe '.param_types' do
     
     it 'raises on param passed of incorrect type' do
-      expect{h.hinted_params('b', 'd')}.to raise_error
-      expect{h.hinted_params('b', 3)}.to raise_error
-      expect{h.hinted_params(['b'], :d)}.to raise_error
+      expect{h.hinted_params('b', 'd')}.to raise_error(TypeError)
+      expect{h.hinted_params('b', 3)}.to raise_error(TypeError)
+      expect{h.hinted_params(['b'], :d)}.to raise_error(TypeError)
     end
 
     it 'does not raise when all passed params are correct type' do

--- a/type_hinting.gemspec
+++ b/type_hinting.gemspec
@@ -6,7 +6,7 @@ require 'type_hinting/version'
 Gem::Specification.new do |spec|
   spec.name          = "type_hinting"
   spec.version       = TypeHinting::VERSION
-  spec.authors       = ["Brian Zeligson"]
+  spec.authors       = ["Brian Zeligson", "Tyler Dooling"]
   spec.email         = ["bzeligson@localytics.com"]
   spec.summary       = %q{Get type safety in your Ruby code}
   spec.homepage      = ""


### PR DESCRIPTION
Crazy simple enhancement here - just preferring `TypeError` over `Exception` to give better clarity on failure and discourage users from `rescue Exception => e`.
